### PR TITLE
basic support for output of the racketscript compiler

### DIFF
--- a/stopify-continuations-compiler/src/common/cannotCapture.ts
+++ b/stopify-continuations-compiler/src/common/cannotCapture.ts
@@ -32,7 +32,8 @@ const knowns = ['Object',
   'WeakMap',
   'WeakSet',
   'ArrayBuffer',
-  'TextDecoder'
+  'TextDecoder',
+  'TextEncoder'
 ];
 
 function cannotCapture(node: t.CallExpression | t.NewExpression): boolean  {

--- a/stopify-continuations-compiler/src/common/cannotCapture.ts
+++ b/stopify-continuations-compiler/src/common/cannotCapture.ts
@@ -42,7 +42,7 @@ function cannotCapture(node: t.CallExpression | t.NewExpression): boolean  {
   return knowns.includes(node.callee.name);
 }
 
-const unavailableOnNode = [ 'TextDecoder' ];
+const unavailableOnNode = [  ];
 const knownBuiltIns = knowns.filter(x => !unavailableOnNode.includes(x))
   .map(o => eval(o));
 

--- a/stopify/src/runtime/node.ts
+++ b/stopify/src/runtime/node.ts
@@ -40,6 +40,7 @@ export function init(
     }
   let g: any = global;
   g.require = require;
+  g.exports = {};
   (suspendRTS as any).g = g;
 
   return suspendRTS;


### PR DESCRIPTION
A few weeks ago I was part of a call with @arjunguha and Sam Tobin-Hochstead about adding support for [Racketscript]( https://github.com/racketscript/racketscript), a subset of Javascript compiled from the Racket language.

We ran into some issues with using Spotify on the generated code, but with a few small changes we could run programs like a factorial function, taking advantage of tail calls and other Stopify features.

From what I remember talking to Arjun, there isn't reason anymore for TextDecoder to be unavailable on Node, or for TextEncoder to be excluded from knowns. This should clean up some minor bitrot.

The addition of g.exports is to support the transpiled version of some ES6 features (I believe named exports), stopify would error without it.

This PR should have everything we talked about that day, and after merging, the compilation output of small Racket programs should work with Stopify.

To show that this does something, I made a small [test repository ](https://github.com/arthertz/racketscript-test) which compiles a Racket program then runs Stopify on it.

I don't know much about Stopify's internals, so I'd love for someone to take a look at this and make sure this won't break anything.